### PR TITLE
Update msw checksum

### DIFF
--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -7,7 +7,7 @@
 /* eslint-disable */
 /* tslint:disable */
 
-const INTEGRITY_CHECKSUM = 'ca2c3cd7453d8c614e2c19db63ede1a1'
+const INTEGRITY_CHECKSUM = 'd1e0e502f550d40a34bee90822e4bf98'
 const bypassHeaderName = 'x-msw-bypass'
 
 let clients = {}


### PR DESCRIPTION
To fix:

[MSW] Detected outdated Service Worker: Currently active Service Worker (ca2c3cd7453d8c614e2c19db63ede1a1) is behind the latest published one (d1e0e502f550d40a34bee90822e4bf98).

Can give this PR other workshops if this is okay.