### PR TITLE
Fix fetchPokemon graphQL query

### DIFF
--- a/src/pokemon.js
+++ b/src/pokemon.js
@@ -29,7 +29,7 @@ const graphql = String.raw
 function fetchPokemon(name, delay = 1500) {
   const endTime = Date.now() + delay
   const pokemonQuery = graphql`
-    query Pokemon($name: String) {
+    query PokemonInfo($name: String) {
       pokemon(name: $name) {
         id
         number


### PR DESCRIPTION
It appears the query name (`Pokemon`) in the graphQL query for `fetchPokemon` doesn't match what's being mocked in https://github.com/kentcdodds/react-suspense/blob/main/src/backend.js#L35 (`PokemonInfo`)

This PR should patch things up.