### PR TITLE
React still showing errors after catching with ErrorBoundary

### DIFF
--- a/src/pokemon.js
+++ b/src/pokemon.js
@@ -74,7 +74,7 @@ function fetchPokemon(name, delay = 1500) {
         pokemon.fetchedAt = formatDate(new Date())
         return pokemon
       } else {
-        return Promise.reject(new Error(`No pokemon with the name "${name}"`))
+        return Promise.reject(`No pokemon with the name "${name}"`)
       }
     })
 }


### PR DESCRIPTION
wrapping the cause of Promise.reject in a new Error() causes it to not go into the ErrorBoundary component and break the app. we would have to change the error.message in ErrorBoundary