### PR TITLE
Use ctx.errors() API to send errors to client

### DIFF
--- a/src/backend.js
+++ b/src/backend.js
@@ -39,13 +39,11 @@ export const handlers = [
         pokemonNames[Math.floor(pokemonNames.length * Math.random())]
       return res(
         ctx.status(404),
-        ctx.data({
-          errors: [
-            {
-              message: `Unsupported pokemon: "${req.variables.name}". Try "${randomName}"`,
-            },
-          ],
-        }),
+        ctx.errors([
+          {
+            message: `Unsupported pokemon: "${req.variables.name}". Try "${randomName}"`,
+          },
+        ]),
       )
     }
   }),


### PR DESCRIPTION
Use `ctx.errors()` instead of `ctx.data()` to exclude `data` object from error response. Fixes #41 