### PR TITLE
delete also data from expirations object, fix setting expiration for the resource

### DIFF
--- a/src/final/04.extra-3.js
+++ b/src/final/04.extra-3.js
@@ -56,8 +56,8 @@ function PokemonCacheProvider({children, cacheTime}) {
       if (!resource) {
         resource = createPokemonResource(lowerName)
         cache.current[lowerName] = resource
-        expirations.current[lowerName] = Date.now() + cacheTime
       }
+      expirations.current[lowerName] = Date.now() + cacheTime
       return resource
     },
     [cacheTime],

--- a/src/final/04.extra-3.js
+++ b/src/final/04.extra-3.js
@@ -41,6 +41,7 @@ function PokemonCacheProvider({children, cacheTime}) {
       for (const [name, time] of Object.entries(expirations.current)) {
         if (time < Date.now()) {
           delete cache.current[name]
+          delete expirations.current[name]
         }
       }
     }, 1000)
@@ -55,8 +56,8 @@ function PokemonCacheProvider({children, cacheTime}) {
       if (!resource) {
         resource = createPokemonResource(lowerName)
         cache.current[lowerName] = resource
+        expirations.current[lowerName] = Date.now() + cacheTime
       }
-      expirations.current[lowerName] = Date.now() + cacheTime
       return resource
     },
     [cacheTime],


### PR DESCRIPTION
@kentcdodds small improvements to the cache example: 
clear also `expirations` objects (so that they don't hang in the memory, and `for` cycle doesn't go through them unnecessarily. 