### PR TITLE
`context` -> `cache`

### DIFF
--- a/src/exercise/04.md
+++ b/src/exercise/04.md
@@ -83,7 +83,7 @@ call. Then retrieve that function from `useContext`.
 [Production deploy](https://react-suspense.netlify.app/isolated/final/04.extra-2.js)
 
 Rather than just having an object living forever in memory, let's put the
-context in a component as a `useRef` so the object is tied to that component. To
+cache in a component as a `useRef` so the object is tied to that component. To
 do this, we'll also have to move the `getPokemonResource` function to the
 component and render it as the value to the provider. Don't forget to memoize it
 with `useCallback` so it's stable between re-renders.


### PR DESCRIPTION
It seems to me that "context" should be "cache" here - we're moving the caching object into a component and tying it to the lifecycle of that provider component using the properties of `useRef`, right?

I was rather confused by these instructions until I realized how this all worked / also remembered that refs = "stable variable tied to the lifecycle of the component" / looked at the answer

thankfully this gave me the motivation to finish the "build an epic react app: context" section I accidentally missed xD