### PR TITLE
Remove --openssl-legacy-provider from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
   },
   "scripts": {
     "serve": "serve -s build",
-    "start": "react-scripts --openssl-legacy-provider start",
-    "build": "react-scripts --openssl-legacy-provider build",
-    "build:profile": "react-scripts --openssl-legacy-provider build --profile",
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "build:profile": "react-scripts build --profile",
     "test": "react-scripts test --env=jsdom",
     "test:coverage": "npm run test -- --watchAll=false",
     "test:exercises": "npm run test -- testing.*exercises\\/ --onlyChanged",


### PR DESCRIPTION
I don't know why this option was added but it's preventing me from running `npm run setup --silent`. It crashes with this:

```
➜  7-react-suspense git:(main) npm run setup --silent
▶️  Starting workshop setup...
      Running the following command: npx "https://gist.github.com/kentcdodds/bb452ffe53a5caa3600197e1d8005733" -q
    ▶️  Starting: System Validation
          Ensuring the correct versions of tools are installed on this computer.
          Running the following command: npx "https://gist.github.com/kentcdodds/abbc32701f78fa70298d444c2303b6d9"
    ✅  Success: System Validation


    ▶️  Starting: Dependency Installation
          Installing third party code dependencies so the workshop works properly on this computer.
          Running the following command: npm install --legacy-peer-deps --no-save
    ✅  Success: Dependency Installation


    ▶️  Starting: Project Validation
          Running validation checks to ensure dependencies were installed properly
          Running the following command: npm run validate -s
/home/someUser/.nvm/versions/node/v16.15.1/bin/node: bad option: --openssl-legacy-provider
    🚨  Failure: Project Validation. Please review the messages above for information on how to troubleshoot and resolve this issue.
```

I run: `node@16.15.1` and `npm@8.19.1`.