### PR TITLE
Fix pixelated Pokemon friends images on exercise 7

### DIFF
--- a/src/suspense-list/right-nav.module.css
+++ b/src/suspense-list/right-nav.module.css
@@ -51,5 +51,6 @@
   height: 50px;
   width: 50px;
   border-radius: 50%;
-  object-fit: cover;
+  object-fit: contain;
+  background-color: white;
 }


### PR DESCRIPTION
Simple fix to avoid pixelated Pokémon Images

Before: 
![before](https://user-images.githubusercontent.com/28774924/210072048-af809c43-8df3-4a95-9488-abb8d9dccf7f.png)

After:
![after](https://user-images.githubusercontent.com/28774924/210072051-4979d226-f843-4d30-bd93-b74ef4805914.png)
