### PR TITLE
updated useTransition changes warning text

### DIFF
--- a/src/exercise/03.md
+++ b/src/exercise/03.md
@@ -57,6 +57,10 @@ does in the recorded videos. However in the future experimental builds of React,
 the `SUSPENSE_CONFIG` option to `useTransition` has been completely removed.
 Read more about this here: https://github.com/facebook/react/pull/19703
 
+Also, keep in mind that removing `SUSPENSE_CONFIG` won't work as intented in our example, since we are using React 17. So, if you remove it, useTransition will run without any delay which means it will always show the Suspense fallback.
+
+Along with the previous change, the order of tuple returned by `useTransition` has also changed. With React 18, the current return value is `[isPending, startTransition]`. So if you like to use it in your code, do not forget to change the order. For those who are interested with learning the reason behind it, can read more about this here: https://github.com/facebook/react/issues/17276
+
 Here's your reminder that you're learning about experimental software which can
 change at any moment without notice 😅
 


### PR DESCRIPTION
-Added warning about the possible results of trying to apply the React 18 changes by removing the SUSPENSE_CONFIG argument.
-Mentioned the returned tuple value order change with React 18